### PR TITLE
Remove redundant build flags

### DIFF
--- a/com.github.babluboy.bookworm.json
+++ b/com.github.babluboy.bookworm.json
@@ -10,8 +10,6 @@
 			"PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
 			"PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
 		},
-	    	"cflags": "-O2",
-		"cxxflags": "-O2"
     },
     "finish-args": [
             "--share=ipc",


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.