### PR TITLE
Stop bundling openjpeg

### DIFF
--- a/com.github.babluboy.bookworm.json
+++ b/com.github.babluboy.bookworm.json
@@ -19,15 +19,7 @@
         "/include",
         "/lib/cmake"
     ],
-    "modules": [{
-            "name": "openjpeg",
-            "buildsystem": "cmake-ninja",
-            "sources": [{
-                "type": "archive",
-                "url": "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
-                "sha256": "63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9"
-            }]
-        },
+    "modules": [
         {
             "name": "poppler",
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
It is already included in the 3.34 GNOME runtime.