### PR TITLE
Update to GNOME 42

### DIFF
--- a/com.github.babluboy.bookworm.json
+++ b/com.github.babluboy.bookworm.json
@@ -1,9 +1,9 @@
 {
     "id": "com.github.babluboy.bookworm",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "42",
     "base": "io.elementary.BaseApp",
-    "base-version": "juno-20.08",
+    "base-version": "juno-21.08",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.babluboy.bookworm",
     "finish-args": [
@@ -13,6 +13,8 @@
         "--socket=wayland",
         "--share=network",
         "--filesystem=home",
+        "--talk-name=org.gtk.vfs.*",
+        "--filesystem=xdg-run/gvfsd",
         "--metadata=X-DConf=migrate-path=/com/github/babluboy/bookworm/"
     ],
     "cleanup": [
@@ -24,10 +26,13 @@
         {
             "name": "poppler",
             "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DENABLE_BOOST=OFF"
+            ],
             "sources": [{
                 "type": "archive",
-                "url": "https://poppler.freedesktop.org/poppler-0.89.0.tar.xz",
-                "sha256": "fba230364537782cc5d43b08d693ef69c36586286349683c7b127156a8ef9b5c"
+                "url": "https://poppler.freedesktop.org/poppler-22.12.0.tar.xz",
+                "sha256": "d9aa9cacdfbd0f8e98fc2b3bb008e645597ed480685757c3e7bc74b4278d15c0"
             }]
         },
         {


### PR DESCRIPTION
- Added GVFS permission.
- Update poppler

Note GNOME 43 doesn't allow to build because only webkit2gtk-4.1 is available.

Close #18 